### PR TITLE
Node integration on browser window creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,11 @@ app.on('ready', () => {
   const htmlPath = path.join('src', 'index.html')
 
   // create a browser window
-  mainWindow = new BrowserWindow()
+  mainWindow = new BrowserWindow({
+        webPreferences: {
+            nodeIntegration: true
+        }
+  })
 
   mainWindow.loadFile(htmlPath)
 })


### PR DESCRIPTION
As of version 5, the default for nodeIntegration changed from true to false. I  have enable it when creating the Browser Window: